### PR TITLE
fix(symlink): update the path for the hive folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,5 @@ deploy-symlink:
 		--s3-prefix sam/$(GIT_HASH) \
 		--tags "environment=$(STAGE)" "branch=$(BRANCH)" "service=$(APPNAME)" \
 		--stack-name $(APPNAME)-$(STAGE)-$(BRANCH)-symlink \
-		--parameter-overrides AppName=$(APPNAME) Stage=$(STAGE) Branch=$(BRANCH) Commit=$(GIT_HASH) DataBucketName=$(DATA_BUCKET_NAME)
+		--parameter-overrides AppName=$(APPNAME) Stage=$(STAGE) Branch=$(BRANCH) Commit=$(GIT_HASH) \
+			DataBucketName=$(DATA_BUCKET_NAME) CurPrefix=$(CUR_PREFIX)

--- a/internal/hive/symlink.go
+++ b/internal/hive/symlink.go
@@ -1,0 +1,46 @@
+package hive
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/rs/zerolog/log"
+)
+
+type S3Client interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+type SymlinkGenerator struct {
+	s3client S3Client
+}
+
+func NewSymlinkGenerator(s3client S3Client) *SymlinkGenerator {
+	return &SymlinkGenerator{
+		s3client: s3client,
+	}
+}
+
+func (sg *SymlinkGenerator) StoreSymlink(ctx context.Context, bucket, prefix string, hivePartitions, symlinkKeys []string) (*s3.PutObjectOutput, error) {
+
+	key := fmt.Sprintf("%s/hive/%s/symlink.txt", prefix, strings.Join(hivePartitions, "/"))
+
+	buf := bytes.NewBufferString(strings.Join(symlinkKeys, "\n"))
+
+	putRes, err := sg.s3client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   buf,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Ctx(ctx).Info().Str("key", key).Str("id", aws.ToString(putRes.ChecksumSHA256)).Msg("put symlink")
+
+	return putRes, nil
+}

--- a/internal/hive/symlink_test.go
+++ b/internal/hive/symlink_test.go
@@ -1,0 +1,88 @@
+package hive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/require"
+)
+
+type MockS3Client struct {
+	putObjectFunc func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+func (m *MockS3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	return m.putObjectFunc(ctx, params, optFns...)
+}
+
+func TestSymlinkGenerator_StoreSymlink(t *testing.T) {
+
+	assert := require.New(t)
+
+	type args struct {
+		ctx            context.Context
+		bucket         string
+		prefix         string
+		hivePartitions []string
+		symlinkKeys    []string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantBucket    string
+		wantKey       string
+		wantBody      string
+		wantPutObject *s3.PutObjectOutput
+		wantErr       bool
+	}{
+		{
+			name: "should create symlink with valid input",
+			args: args{
+				ctx:            context.TODO(),
+				bucket:         "test-bucket",
+				prefix:         "test-prefix",
+				hivePartitions: []string{"year=2022", "month=1"},
+				symlinkKeys: []string{
+					"parquet/test-managment-cur/20220401-20220501/20220503T120125Z/test-managment-cur-00001.snappy.parquet",
+					"parquet/test-managment-cur/20220401-20220501/20220503T120125Z/test-managment-cur-00002.snappy.parquet",
+				},
+			},
+			wantBucket:    "test-bucket",
+			wantKey:       "test-prefix/hive/year=2022/month=1/symlink.txt",
+			wantBody:      "parquet/test-managment-cur/20220401-20220501/20220503T120125Z/test-managment-cur-00001.snappy.parquet\nparquet/test-managment-cur/20220401-20220501/20220503T120125Z/test-managment-cur-00002.snappy.parquet",
+			wantPutObject: &s3.PutObjectOutput{},
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sg := &SymlinkGenerator{
+				s3client: &MockS3Client{
+					putObjectFunc: func(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+						assert.Equal(tt.wantBucket, aws.ToString(params.Bucket))
+						assert.Equal(tt.wantKey, aws.ToString(params.Key))
+
+						data, err := io.ReadAll(params.Body)
+						assert.NoError(err)
+
+						fmt.Println(string(data))
+
+						assert.Equal(tt.wantBody, string(data))
+
+						return &s3.PutObjectOutput{}, nil
+					},
+				},
+			}
+			got, err := sg.StoreSymlink(tt.args.ctx, tt.args.bucket, tt.args.prefix, tt.args.hivePartitions, tt.args.symlinkKeys)
+			if tt.wantErr {
+				assert.Error(err)
+			}
+
+			assert.Equal(tt.wantPutObject, got)
+		})
+	}
+}

--- a/sam/app/symlink.yaml
+++ b/sam/app/symlink.yaml
@@ -21,7 +21,11 @@ Parameters:
     Default: info
     AllowedValues: ["trace", "debug", "info", "warn", "error", "fatal", "panic"]
   DataBucketName:
+    Description: The name of the bucket you have configured to receive CUR files.
     Type: String
+  CurPrefix:
+    Type: String
+    Description: The prefix for the CUR files in the bucket, this should exclude the leading '/'.
 
 Conditions:
   IsDev: !Equals [!Ref Stage, "dev"]
@@ -69,3 +73,6 @@ Resources:
                 bucket:
                   name:
                     - !Ref DataBucketName
+                object:
+                  key:
+                    - prefix: !Ref CurPrefix


### PR DESCRIPTION
Based on the convention set by the inventory service I have moved the hive folder to the root of the cur files.
