### PR TITLE
fix(hive): updated hive logic to use arrays rather than maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOAMD64=v2 go build -ldflags "-s -w -X main.commit=$(GIT_HASH)" -o dist/ ./cmd/...
+	CGO_ENABLED=0 GOAMD64=v2 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.commit=$(GIT_HASH)" -o dist/ ./cmd/...
 
 .PHONY: clean
 clean:

--- a/internal/hive/hive.go
+++ b/internal/hive/hive.go
@@ -5,15 +5,20 @@ import (
 	"strings"
 )
 
-type HivePartitions map[string]string
+type HivePartition struct {
+	Key   string
+	Value string
+}
+
+type HivePartitions []HivePartition
 
 // PathString convert a map of partition key/values to a path string
 func (hv HivePartitions) PathString() string {
 
 	var parts []string
 
-	for k, v := range hv {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+	for _, v := range hv {
+		parts = append(parts, fmt.Sprintf("%s=%s", v.Key, v.Value))
 	}
 
 	return strings.Join(parts, "/")
@@ -31,10 +36,21 @@ func ParsePathString(path string) HivePartitions {
 			kv := strings.SplitN(part, "=", 2)
 
 			if len(kv) == 2 {
-				hv[kv[0]] = kv[1]
+				// hv[kv[0]] = kv[1]
+				hv = append(hv, HivePartition{Key: kv[0], Value: kv[1]})
 			}
 		}
 	}
 
 	return hv
+}
+
+func (hv HivePartitions) Get(key string) string {
+	for _, v := range hv {
+		if key == v.Key {
+			return v.Value
+		}
+	}
+
+	return ""
 }

--- a/internal/hive/hive_test.go
+++ b/internal/hive/hive_test.go
@@ -19,16 +19,16 @@ func TestParsePathString(t *testing.T) {
 			name: "should parse valid path",
 			args: args{path: "hive/year=2020/month=1/symlink.txt"},
 			want: HivePartitions{
-				"year":  "2020",
-				"month": "1",
+				{Key: "year", Value: "2020"},
+				{Key: "month", Value: "1"},
 			},
 		},
 		{
 			name: "should parse valid path",
 			args: args{path: "hive/year=2020/month=1/symlink.txt"},
 			want: HivePartitions{
-				"year":  "2020",
-				"month": "1",
+				{Key: "year", Value: "2020"},
+				{Key: "month", Value: "1"},
 			},
 		},
 	}
@@ -48,7 +48,10 @@ func TestHivePartitions_PathString(t *testing.T) {
 	}{
 		{
 			name: "should build valid path",
-			hv:   HivePartitions{"year": "2022", "month": "1"},
+			hv: HivePartitions{
+				{Key: "year", Value: "2022"},
+				{Key: "month", Value: "1"},
+			},
 			want: "year=2022/month=1",
 		},
 	}

--- a/internal/hive/symlink_test.go
+++ b/internal/hive/symlink_test.go
@@ -27,7 +27,7 @@ func TestSymlinkGenerator_StoreSymlink(t *testing.T) {
 		ctx            context.Context
 		bucket         string
 		prefix         string
-		hivePartitions map[string]string
+		hivePartitions HivePartitions
 		symlinkKeys    []string
 	}
 	tests := []struct {
@@ -42,10 +42,13 @@ func TestSymlinkGenerator_StoreSymlink(t *testing.T) {
 		{
 			name: "should create symlink with valid input",
 			args: args{
-				ctx:            context.TODO(),
-				bucket:         "test-bucket",
-				prefix:         "test-prefix",
-				hivePartitions: map[string]string{"year": "2022", "month": "1"},
+				ctx:    context.TODO(),
+				bucket: "test-bucket",
+				prefix: "test-prefix",
+				hivePartitions: HivePartitions{
+					{Key: "year", Value: "2022"},
+					{Key: "month", Value: "1"},
+				},
 				symlinkKeys: []string{
 					"parquet/test-managment-cur/20220401-20220501/20220503T120125Z/test-managment-cur-00001.snappy.parquet",
 					"parquet/test-managment-cur/20220401-20220501/20220503T120125Z/test-managment-cur-00002.snappy.parquet",

--- a/internal/partitions/handler.go
+++ b/internal/partitions/handler.go
@@ -91,9 +91,12 @@ func (h *Handler) processCreated(ctx context.Context, created *s3created.ObjectC
 		return nil, err
 	}
 
+	year := fmt.Sprintf("%d", startDate.Year())
+	month := fmt.Sprintf("%d", startDate.Month())
+
 	hivePartitions := hive.HivePartitions{
-		"year":  fmt.Sprintf("%d", startDate.Year()),
-		"month": fmt.Sprintf("%d", startDate.Month()),
+		{Key: "year", Value: year},
+		{Key: "month", Value: month},
 	}
 
 	keys := make([]string, len(manifest.ReportKeys))
@@ -107,7 +110,7 @@ func (h *Handler) processCreated(ctx context.Context, created *s3created.ObjectC
 		return nil, err
 	}
 
-	err = h.pman.CreatePartition(ctx, hivePartitions["year"], hivePartitions["month"])
+	err = h.pman.CreatePartition(ctx, year, month)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Every time I use maps, then iterate over keys to build something I get burnt by this. A good reminder to never rely on order of keys in a map :facepalm:.
